### PR TITLE
check users ldap groups against allowed list

### DIFF
--- a/common/persons_api/api.go
+++ b/common/persons_api/api.go
@@ -1,0 +1,96 @@
+package persons_api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+)
+
+type Client struct {
+	clientId     string
+	clientSecret string
+	accessToken  string
+	httpClient   *http.Client
+	baseUrl      string
+}
+
+func NewClient(id, secret, baseUrl, authUrl string) (*Client, error) {
+	httpClient := &http.Client{}
+	c := &Client{
+		httpClient:   httpClient,
+		clientId:     id,
+		clientSecret: secret,
+		baseUrl:      baseUrl,
+	}
+	accessToken, err := c.GetAccessToken(authUrl)
+	if err != nil {
+		return nil, err
+	}
+	c.accessToken = accessToken
+	return c, nil
+}
+
+func (c *Client) GetAccessToken(authUrl string) (string, error) {
+	authReqBody, err := json.Marshal(AuthReq{
+		Audience:     "api.sso.mozilla.com",
+		Scope:        "classification:public display:public",
+		GrantType:    "client_credentials",
+		ClientId:     c.clientId,
+		ClientSecret: c.clientSecret})
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := c.httpClient.Post(authUrl, "application/json", bytes.NewBuffer(authReqBody))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	var authResp AuthResp
+	err = json.Unmarshal(body, &authResp)
+	if err != nil {
+		return "", err
+	}
+
+	return authResp.AccessToken, nil
+}
+
+func (c *Client) GetPersonByEmail(primaryEmail string) (*Person, error) {
+	req, err := http.NewRequest("GET", c.baseUrl+"/v2/user/primary_email/"+primaryEmail, nil)
+	req.Header.Add("Authorization", "Bearer "+c.accessToken)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+
+	p, err := UnmarshalPerson(body)
+	if err != nil {
+		return nil, err
+	}
+
+	return &p, nil
+}
+
+type AuthReq struct {
+	Audience     string `json:"audience"`
+	Scope        string `json:"scope"`
+	GrantType    string `json:"grant_type"`
+	ClientId     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+}
+
+type AuthResp struct {
+	AccessToken string `json:"access_token"`
+	Scope       string `json:"scope"`
+	ExpiresIn   int    `json:"expires_in"`
+	TokenType   string `json:"token_type"`
+}

--- a/common/persons_api/persons.go
+++ b/common/persons_api/persons.go
@@ -1,0 +1,211 @@
+// To parse and unparse this JSON data, add this code to your project and do:
+//
+//    person, err := UnmarshalPerson(bytes)
+//    bytes, err = person.Marshal()
+
+package persons_api
+
+import "encoding/json"
+
+func UnmarshalPerson(data []byte) (Person, error) {
+	var r Person
+	err := json.Unmarshal(data, &r)
+	return r, err
+}
+
+func (r *Person) Marshal() ([]byte, error) {
+	return json.Marshal(r)
+}
+
+type Person struct {
+	AccessInformation AccessInformationValuesArray    `json:"access_information"`
+	Active            StandardAttributeBoolean        `json:"active"`
+	AlternativeName   StandardAttributeString         `json:"alternative_name"`
+	Created           StandardAttributeString         `json:"created"`
+	Description       StandardAttributeString         `json:"description"`
+	FirstName         StandardAttributeString         `json:"first_name"`
+	FunTitle          StandardAttributeString         `json:"fun_title"`
+	Identities        IdentitiesAttributesValuesArray `json:"identities"`
+	Languages         StandardAttributeValues         `json:"languages"`
+	LastModified      StandardAttributeString         `json:"last_modified"`
+	LastName          StandardAttributeString         `json:"last_name"`
+	Location          StandardAttributeString         `json:"location"`
+	LoginMethod       StandardAttributeString         `json:"login_method"`
+	PGPPublicKeys     StandardAttributeValues         `json:"pgp_public_keys"`
+	PhoneNumbers      StandardAttributeValues         `json:"phone_numbers"`
+	Picture           StandardAttributeString         `json:"picture"`
+	PrimaryEmail      StandardAttributeString         `json:"primary_email"`
+	PrimaryUsername   StandardAttributeString         `json:"primary_username"`
+	Pronouns          StandardAttributeString         `json:"pronouns"`
+	Schema            string                          `json:"schema"`
+	SSHPublicKeys     StandardAttributeValues         `json:"ssh_public_keys"`
+	StaffInformation  StaffInformationValuesArray     `json:"staff_information"`
+	Tags              StandardAttributeValues         `json:"tags"`
+	Timezone          StandardAttributeString         `json:"timezone"`
+	Uris              StandardAttributeValues         `json:"uris"`
+	UserID            StandardAttributeString         `json:"user_id"`
+	Usernames         StandardAttributeValues         `json:"usernames"`
+	UUID              StandardAttributeString         `json:"uuid"`
+}
+
+type AccessInformationValuesArray struct {
+	AccessProvider AccessProviderAttribute `json:"access_provider"`
+	Hris           HrisAttribute           `json:"hris"`
+	LDAP           LDAPAttribute           `json:"ldap"`
+	Mozilliansorg  MozilliansorgAttribute  `json:"mozilliansorg"`
+}
+
+type AccessProviderAttribute struct {
+	Metadata  AccessProviderMetadata `json:"metadata"`
+	Signature Signature              `json:"signature"`
+	Values    map[string]interface{} `json:"values"`
+}
+
+type AccessProviderMetadata struct {
+	Display        interface{}    `json:"display"`
+	Classification Classification `json:"classification"`
+	Created        string         `json:"created"`
+	LastModified   string         `json:"last_modified"`
+	Verified       bool           `json:"verified"`
+}
+
+type Signature struct {
+	Additional []PublisherLax `json:"additional"`
+	Publisher  Publisher      `json:"publisher"`
+}
+
+type PublisherLax struct {
+	Alg   Alg     `json:"alg"`
+	Name  *string `json:"name"`
+	Typ   Typ     `json:"typ"`
+	Value string  `json:"value"`
+}
+
+type Publisher struct {
+	Alg   Alg                `json:"alg"`
+	Name  PublisherAuthority `json:"name"`
+	Typ   Typ                `json:"typ"`
+	Value string             `json:"value"`
+}
+
+type HrisAttribute struct {
+	Metadata  Metadata               `json:"metadata"`
+	Signature Signature              `json:"signature"`
+	Values    map[string]interface{} `json:"values"`
+}
+
+type LDAPAttribute struct {
+	Metadata  Metadata               `json:"metadata"`
+	Signature Signature              `json:"signature"`
+	Values    map[string]interface{} `json:"values"`
+}
+
+type MozilliansorgAttribute struct {
+	Metadata  Metadata               `json:"metadata"`
+	Signature Signature              `json:"signature"`
+	Values    map[string]interface{} `json:"values"`
+}
+
+type StandardAttributeString struct {
+	Metadata  Metadata  `json:"metadata"`
+	Signature Signature `json:"signature"`
+	Value     string    `json:"value"`
+}
+
+type StandardAttributeBoolean struct {
+	Metadata  Metadata  `json:"metadata"`
+	Signature Signature `json:"signature"`
+	Value     bool      `json:"value"`
+}
+
+type Metadata struct {
+	Classification Classification  `json:"classification"`
+	Created        string          `json:"created"`
+	Display        DinoParkDisplay `json:"display"`
+	LastModified   string          `json:"last_modified"`
+	Verified       bool            `json:"verified"`
+}
+
+type IdentitiesAttributesValuesArray struct {
+	BugzillaMozillaOrgID           *StandardAttributeString `json:"bugzilla_mozilla_org_id,omitempty"`
+	BugzillaMozillaOrgPrimaryEmail *StandardAttributeString `json:"bugzilla_mozilla_org_primary_email,omitempty"`
+	Custom1_PrimaryEmail           *StandardAttributeString `json:"custom_1_primary_email,omitempty"`
+	Custom2_PrimaryEmail           *StandardAttributeString `json:"custom_2_primary_email,omitempty"`
+	Custom3_PrimaryEmail           *StandardAttributeString `json:"custom_3_primary_email,omitempty"`
+	FirefoxAccountsID              *StandardAttributeString `json:"firefox_accounts_id,omitempty"`
+	FirefoxAccountsPrimaryEmail    *StandardAttributeString `json:"firefox_accounts_primary_email,omitempty"`
+	GithubIDV3                     *StandardAttributeString `json:"github_id_v3,omitempty"`
+	GithubIDV4                     *StandardAttributeString `json:"github_id_v4,omitempty"`
+	GithubPrimaryEmail             *StandardAttributeString `json:"github_primary_email,omitempty"`
+	GoogleOauth2ID                 *StandardAttributeString `json:"google_oauth2_id,omitempty"`
+	GooglePrimaryEmail             *StandardAttributeString `json:"google_primary_email,omitempty"`
+	MozillaLDAPID                  *StandardAttributeString `json:"mozilla_ldap_id,omitempty"`
+	MozillaLDAPPrimaryEmail        *StandardAttributeString `json:"mozilla_ldap_primary_email,omitempty"`
+	MozillaPOSIXID                 *StandardAttributeString `json:"mozilla_posix_id,omitempty"`
+	MozilliansorgID                *StandardAttributeString `json:"mozilliansorg_id,omitempty"`
+}
+
+type StandardAttributeValues struct {
+	Metadata  Metadata    `json:"metadata"`
+	Signature Signature   `json:"signature"`
+	Values    interface{} `json:"values"`
+}
+
+type StaffInformationValuesArray struct {
+	CostCenter     StandardAttributeString  `json:"cost_center"`
+	Director       StandardAttributeBoolean `json:"director"`
+	Manager        StandardAttributeBoolean `json:"manager"`
+	OfficeLocation StandardAttributeString  `json:"office_location"`
+	Staff          StandardAttributeBoolean `json:"staff"`
+	Team           StandardAttributeString  `json:"team"`
+	Title          StandardAttributeString  `json:"title"`
+	WorkerType     StandardAttributeString  `json:"worker_type"`
+	WprDeskNumber  StandardAttributeString  `json:"wpr_desk_number"`
+}
+
+type Classification string
+
+const (
+	WORKGROUPCONFIDENTIALSTAFFONLY Classification = "WORKGROUP CONFIDENTIAL: STAFF ONLY"
+	WORKGROUPCONFIDENTIAL          Classification = "WORKGROUP CONFIDENTIAL"
+	IndividualConfidential         Classification = "INDIVIDUAL CONFIDENTIAL"
+	MozillaConfidential            Classification = "MOZILLA CONFIDENTIAL"
+	PUBLIC                         Classification = "PUBLIC"
+)
+
+type Alg string
+
+const (
+	Ed25519 Alg = "ED25519"
+	Hs256   Alg = "HS256"
+	RSA     Alg = "RSA"
+	Rs256   Alg = "RS256"
+)
+
+type Typ string
+
+const (
+	Jws Typ = "JWS"
+	PGP Typ = "PGP"
+)
+
+type PublisherAuthority string
+
+const (
+	AccessProvider PublisherAuthority = "access_provider"
+	Cis            PublisherAuthority = "cis"
+	Hris           PublisherAuthority = "hris"
+	LDAP           PublisherAuthority = "ldap"
+	Mozilliansorg  PublisherAuthority = "mozilliansorg"
+)
+
+type DinoParkDisplay string
+
+const (
+	Authenticated DinoParkDisplay = "authenticated"
+	Ndaed         DinoParkDisplay = "ndaed"
+	Private       DinoParkDisplay = "private"
+	Staff         DinoParkDisplay = "staff"
+	Vouched       DinoParkDisplay = "vouched"
+	Public        DinoParkDisplay = "public"
+)

--- a/foxsec-slack-bot/slackutils.go
+++ b/foxsec-slack-bot/slackutils.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -18,7 +19,13 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var rxEmail = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
+
 func checkUsersGroups(email string) (bool, error) {
+	if len(email) > 254 || !rxEmail.MatchString(email) {
+		return false, fmt.Errorf("Email (%s) is invalid", email)
+	}
+
 	person, err := globalConfig.personsClient.GetPersonByEmail(email)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
Does an authorization check based on the users ldap groups.

note: `common/persons_api/persons.go` was generated by a json schema to code generator and then simplified a bit by hand, so that's why it is a bit weird looking. 