### PR TITLE
Confirmation-related tweaks

### DIFF
--- a/common/alert.go
+++ b/common/alert.go
@@ -9,6 +9,8 @@ const (
 	ALERT_NEW          = "NEW"
 	ALERT_ACKNOWLEDGED = "ACKNOWLEDGED"
 	ALERT_ESCALATED    = "ESCALATED"
+
+	ESCALATE_TO = "escalate_to"
 )
 
 type Alert struct {
@@ -31,10 +33,12 @@ Summary: %s
 Severity: %s
 Category: %s
 Timestamp: %s
-Payload: %s
 Metadata:
-%s`,
-		a.Id, a.Summary, a.Severity, a.Category, a.Timestamp, a.Payload, md)
+%s
+Payload (message sent to user):
+%s
+`,
+		a.Id, a.Summary, a.Severity, a.Category, a.Timestamp, md, a.Payload)
 	return s
 }
 

--- a/scheduled-tasks/alert-escalator/escalator.go
+++ b/scheduled-tasks/alert-escalator/escalator.go
@@ -66,12 +66,13 @@ func Escalator(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, alert := range alerts {
-		log.Infof("Check alert %s", alert.Id)
+		log.Infof("Checking alert %s", alert.Id)
 		if alert.IsStatus(common.ALERT_NEW) && alert.OlderThan(ALERT_ESCALATION_TTL) {
 			log.Infof("Escalating alert %s", alert.Id)
 			alert.SetMetadata("status", common.ALERT_ESCALATED)
 
 			returnEarly := false
+
 			err := SESCLIENT.SendEscalationEmail(alert)
 			if err != nil {
 				log.Errorf("Error escalating alert (%s). Err: %s", alert.Id, err)


### PR DESCRIPTION
* add support for 'escalate_to' alert metadata
* don't change already escalated alerts from the slackbot
* clean up some logging and alert pretty print