### PR TITLE
Whitelist email support

### DIFF
--- a/common/whitelisted_ip.go
+++ b/common/whitelisted_ip.go
@@ -1,26 +1,37 @@
 package common
 
 import (
+	"fmt"
 	"time"
 )
 
-type WhitelistedIP struct {
-	IP        string    `json:"ip"`
+const (
+	IP_TYPE    = "ip"
+	EMAIL_TYPE = "email"
+)
+
+type WhitelistedObject struct {
+	Object    string    `json:"object"`
+	Type      string    `json:"type"`
 	ExpiresAt time.Time `json:"expires_at"`
 	CreatedBy string    `json:"created_by"`
 }
 
-func NewWhitelistedIP(ip string, expiresAt time.Time, createdBy string) *WhitelistedIP {
+func NewWhitelistedObject(object, typestr string, expiresAt time.Time, createdBy string) (*WhitelistedObject, error) {
+	if typestr != IP_TYPE && typestr != EMAIL_TYPE {
+		return nil, fmt.Errorf("Invalid typestr %s. Only %s and %s allowed", typestr, IP_TYPE, EMAIL_TYPE)
+	}
 	if expiresAt.IsZero() {
 		expiresAt = time.Now().Add(time.Hour * 24)
 	}
-	return &WhitelistedIP{
-		IP:        ip,
+	return &WhitelistedObject{
+		Object:    object,
+		Type:      typestr,
 		ExpiresAt: expiresAt,
 		CreatedBy: createdBy,
-	}
+	}, nil
 }
 
-func (ip *WhitelistedIP) IsExpired() bool {
-	return ip.ExpiresAt.Before(time.Now())
+func (wo *WhitelistedObject) IsExpired() bool {
+	return wo.ExpiresAt.Before(time.Now())
 }

--- a/slackbot-background/background.go
+++ b/slackbot-background/background.go
@@ -16,10 +16,13 @@ import (
 )
 
 const (
-	WHITELIST_IP_SLASH_COMMAND         = "/whitelist_ip"
-	STAGING_WHITELIST_IP_SLASH_COMMAND = "/staging_whitelist_ip"
-	DEFAULT_EXPIRATION_DURATION        = time.Hour * 24
-	DURATION_DOC                       = "FoxsecBot uses Go's time.ParseDuration internally " +
+	WHITELIST_IP_SLASH_COMMAND            = "/whitelist_ip"
+	STAGING_WHITELIST_IP_SLASH_COMMAND    = "/staging_whitelist_ip"
+	WHITELIST_EMAIL_SLASH_COMMAND         = "/whitelist_email"
+	STAGING_WHITELIST_EMAIL_SLASH_COMMAND = "/staging_whitelist_email"
+
+	DEFAULT_EXPIRATION_DURATION = time.Hour * 24
+	DURATION_DOC                = "FoxsecBot uses Go's time.ParseDuration internally " +
 		"with some custom checks. Examples: '72h' or '2h45m'. " +
 		"Valid time units are 'm' and 'h'. If you omit a duration, " +
 		"the default (24 hours) is used. If your duration is under " +
@@ -34,6 +37,13 @@ var (
 	DB      *common.DBClient
 
 	config = &common.Configuration{}
+
+	ALLOWED_COMMANDS = []string{
+		WHITELIST_IP_SLASH_COMMAND,
+		STAGING_WHITELIST_IP_SLASH_COMMAND,
+		WHITELIST_EMAIL_SLASH_COMMAND,
+		STAGING_WHITELIST_EMAIL_SLASH_COMMAND,
+	}
 )
 
 func init() {
@@ -89,6 +99,15 @@ func InitConfig() {
 	log.Infof("Allowed LDAP Groups for Whitelist Command: %v", config.AllowedLDAPGroups)
 }
 
+func allowedCommand(cmd string) bool {
+	for _, allowedCmd := range ALLOWED_COMMANDS {
+		if allowedCmd == cmd {
+			return true
+		}
+	}
+	return false
+}
+
 func alertEscalator(ctx context.Context) error {
 	alerts, err := DB.GetAllAlerts(ctx)
 	if err != nil {
@@ -129,7 +148,7 @@ func SlackbotBackground(ctx context.Context, psmsg pubsub.Message) error {
 
 	if td.Action == common.SlashCommand {
 		log.Infof("Got slash command: %s", td.SlashCommand.Cmd)
-		if td.SlashCommand.Cmd == WHITELIST_IP_SLASH_COMMAND || td.SlashCommand.Cmd == STAGING_WHITELIST_IP_SLASH_COMMAND {
+		if allowedCommand(td.SlashCommand.Cmd) {
 			resp, err := handleWhitelistCmd(ctx, td.SlashCommand, DB)
 			if err != nil {
 				log.Errorf("error handling whitelist command: %s", err)
@@ -165,7 +184,7 @@ func SlackbotBackground(ctx context.Context, psmsg pubsub.Message) error {
 		if err != nil {
 			log.Errorf("Error escalating alerts: %s", err)
 		}
-		err = DB.RemoveExpiredWhitelistedIps(ctx)
+		err = DB.RemoveExpiredWhitelistedObjects(ctx)
 		if err != nil {
 			log.Errorf("Error purging expired whitelisted ips: %s", err)
 		}

--- a/slackbot-http/http.go
+++ b/slackbot-http/http.go
@@ -53,6 +53,16 @@ func InitConfig() {
 	}
 
 	globalConfig.triggerTopicName = os.Getenv("TRIGGER_TOPIC_NAME")
+
+	topic := globalConfig.pubsubClient.Topic(globalConfig.triggerTopicName)
+	ok, err := topic.Exists(context.Background())
+	if err != nil {
+		log.Errorf("Error checking whether topic (%s) exists. Err: %s", globalConfig.triggerTopicName, err)
+		return
+	}
+	if !ok {
+		log.Fatalf("Topic `%s` does not exist.", globalConfig.triggerTopicName)
+	}
 }
 
 func InteractionCallbackParse(reqBody []byte) (*slack.InteractionCallback, error) {
@@ -128,14 +138,6 @@ func SlackbotHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if data != nil {
 		topic := globalConfig.pubsubClient.Topic(globalConfig.triggerTopicName)
-		ok, err := topic.Exists(r.Context())
-		if err != nil {
-			log.Errorf("Error checking whether topic (%s) exists. Err: %s", globalConfig.triggerTopicName, err)
-			return
-		}
-		if !ok {
-			log.Fatalf("Topic `%s` does not exist.", globalConfig.triggerTopicName)
-		}
 		defer topic.Stop()
 
 		psmsg, err := data.ToPubSubMessage()


### PR DESCRIPTION
Adds support for `/whitelist_email` (and `/staging_whitelist_email`) that functions exactly like `/whitelist_ip`.

Whitelisted objects are stored under the same namespace with different datastore kinds.

This PR includes an additional change for moving the checking of the pubsub topic existing in SlackbotHTTP into the init phase rather than on each http request.

Fixes #21 
Depends on https://bugzilla.mozilla.org/show_bug.cgi?id=1564951