### PR TITLE
Refresh persons api access token every 1 hour

### DIFF
--- a/slackbot-background/background.go
+++ b/slackbot-background/background.go
@@ -86,6 +86,17 @@ func InitConfig() {
 		log.Fatalf("Could not create persons api client: %s", err)
 	}
 
+	go func() {
+		for {
+			time.Sleep(time.Hour)
+			log.Info("Refreshing access token")
+			err = globals.personsClient.RefreshAccessToken()
+			if err != nil {
+				log.Errorf("Error refreshing persons access token: %s", err)
+			}
+		}
+	}()
+
 	log.Infof("Allowed LDAP Groups for Whitelist Command: %v", config.AllowedLDAPGroups)
 }
 


### PR DESCRIPTION
* Implement refresh access token method
* Add background process to refresh the access token every 1 hour

Fixes authorization failures we were seeing with the whitelist command. Was only showing up after being deployed for a while because we had to wait until the access token expired.