### PR TITLE
auth0pull ordering fix and performance improvement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get install google-cloud-sdk-datastore-emulator net-tools netcat -y
 
 COPY . /go/src/github.com/mozilla-services/foxsec-pipeline-contrib
 RUN cd /go/src/github.com/mozilla-services/foxsec-pipeline-contrib && \
-    GO111MODULE=on go get ./...
+    GO111MODULE=on GOPROXY=https://proxy.golang.org go get ./...
 
 COPY docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
* Fixed a misunderstanding of https://auth0.com/docs/logs#get-logs-by-checkpoint - When using the
`from` parameter, the `sort` parameter is ignored. This commit includes actually sorting the logs that are retrieved to get the actual last log id.
* Log to stackdriver directly in the main "get logs" loop instead of looping over all log events twice.
* If an error is encountered, save progress so that duplicate events are not sent.