### PR TITLE
Remove alerts older than 14 days from datastore

### DIFF
--- a/common/db_test.go
+++ b/common/db_test.go
@@ -53,6 +53,13 @@ func TestAlertDB(t *testing.T) {
 	assert.True(t, a.Timestamp.Equal(alerts[0].Timestamp))
 	assert.Equal(t, nna.Metadata, alerts[0].Metadata)
 
+	err = db.RemoveAlertsOlderThan(context.Background(), time.Nanosecond)
+	assert.NoError(t, err)
+
+	alerts, err = db.GetAllAlerts(context.Background())
+	assert.NoError(t, err)
+	assert.True(t, 0 == len(alerts))
+
 	err = db.Close()
 	assert.NoError(t, err)
 }

--- a/slackbot-background/background.go
+++ b/slackbot-background/background.go
@@ -29,6 +29,8 @@ const (
 		"5 minutes, it is increased to 5 minutes. If you do not want the " +
 		"whitelisted IP to expire, put 'never' as the expiration. This " +
 		"will make the expiration duration roughly ten years from now."
+
+	FOURTEEN_DAYS_AGO = time.Hour * 24 * 14
 )
 
 var (
@@ -198,6 +200,10 @@ func SlackbotBackground(ctx context.Context, psmsg pubsub.Message) error {
 		err = DB.RemoveExpiredWhitelistedObjects(ctx)
 		if err != nil {
 			log.Errorf("Error purging expired whitelisted ips: %s", err)
+		}
+		err = DB.RemoveAlertsOlderThan(ctx, FOURTEEN_DAYS_AGO)
+		if err != nil {
+			log.Errorf("Error removing old alerts: %s", err)
 		}
 	}
 


### PR DESCRIPTION
We are starting to get a lot of alerts sitting in there that are no longer needed. This will remove alerts older than 14 days as part of the slackbot workers every-X-minutes run.